### PR TITLE
BIP-146 using lower S at start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 dist/
+.idea
+.tmp

--- a/ecc/sign.go
+++ b/ecc/sign.go
@@ -86,6 +86,10 @@ func SingDer(message []byte, privateKey []byte, entryPointes []byte) []byte {
 		edr := new(big.Int).Add(e, dr)
 		s = new(big.Int).Mod(new(big.Int).Mul(kinv, edr), n)
 
+		if s.Cmp(new(big.Int).Div(n, big.NewInt(2))) > 0 {
+			s = new(big.Int).Sub(n, s)
+		}
+
 		if s.Cmp(big.NewInt(0)) != 0 {
 			break
 		}
@@ -118,21 +122,10 @@ func SingInput(privateKey []byte, message []byte, sigHash int) string {
 	R := signature[4 : 4+lengthR]
 	lengthS := int(signature[5+lengthR])
 	S := signature[5+lengthR+1:]
-	sAsBigint := formating.BytesToInt(S)
 
-	var newS []byte
-
-	if lengthS == 33 {
-		newSAsBigint := new(big.Int).Sub(P256k1().Params().N, sAsBigint)
-		newS = encodeBigInt(newSAsBigint)
-		lengthS -= 1
-		lengthTotal -= 1
-	} else {
-		newS = S
-	}
 	newSignature := append([]byte{derPrefix, byte(lengthTotal), byte(derTypeInt), byte(lengthR)}, R...)
 	newSignature = append(newSignature, byte(derTypeInt), byte(lengthS))
-	newSignature = append(newSignature, newS...)
+	newSignature = append(newSignature, S...)
 	newSignature = append(newSignature, byte(sigHash))
 	return formating.BytesToHex(newSignature)
 }


### PR DESCRIPTION
Hello!

### Problem

As you know, due to BIP-146 https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki#user-content-LOW_S, we should use only a lower S

And there is a check in the code (`if lengthS == 33 {...}`) that converts higher S to lower S, but there are a few problems with it
- first one, this check is indirect, because, if I understand correctly, 31, 32 and 33 bytes are correct lengths for S part of signature
- second one and the most important, sometimes it leads to the incorrect signature

About second problem: sometimes, with some circumstances, after this check and calculating lower S, encoded lower S has length 31 bytes (that is valid for S too), but `encodeBigInt` function in this case unconditionally adds a leading zero byte, to make length equal 32 bytes, and if before adding zero byte, the s signature had leading byte less than 0x7F byte (that means that we have zero leading bit and is being considered as a positive), it leads to `-26: mandatory-script-verify-flag-failed (Non-canonical DER signature)` in bitcoin

This check fails https://github.com/bitcoin/bitcoin/blob/80ad135a5e54e8a065fee5ef36e57034679111ab/src/script/interpreter.cpp#L159
```
    // Null bytes at the start of S are not allowed, unless S would otherwise be
    // interpreted as a negative number.
    if (lenS > 1 && (sig[lenR + 6] == 0x00) && !(sig[lenR + 7] & 0x80)) return false;
```

### Solution

So the solution in this MR is to explicitly check if we have a high S at the start, and if so, we calculating the low S at this point, and after that we don't need to have check of `if lengthS == 33 {...}`
